### PR TITLE
Run cypress in container with fixed version of Chrome 79 

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -11,6 +11,7 @@ jobs:
     name: Integration test
     if: '!github.event.deleted'
     runs-on: ubuntu-16.04
+    container: cypress/browsers:node12.13.0-chrome78-ff70
     steps:
       - uses: actions/checkout@master
       - name: Setup Node

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -72,6 +72,7 @@ jobs:
     name: Integration test
     if: '!github.event.deleted'
     runs-on: ubuntu-16.04
+    container: cypress/browsers:node12.14.0-chrome79-ff71
     steps:
       - uses: actions/checkout@master
       - name: Setup Node
@@ -108,7 +109,7 @@ jobs:
         with:
           name: cypress-videos
           path: cypress/videos
-      - name: Upload coverage to Codecov  
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
We are now again seeing builds on GitHub Actions stalling because
Cypress cannot connect to Chrome. This seems to be an issue from
Chrome 80 and on.

The issue might be fixed by upgrading to Cypress 4.

For now we simply run Chrome from a Docker image provided by Cypress 
with a fixed version.

See https://github.com/cypress-io/github-action#docker-image