### PR TITLE
Cypress run

### DIFF
--- a/docker-compose.cypress.yml
+++ b/docker-compose.cypress.yml
@@ -1,0 +1,26 @@
+# How to use this file:
+#
+# 1. Ensure that your local X11 server will allow remote clients. See
+# xhost(1). If all else fails, `xhost +` will disable all access
+# control, which can be acceptable if you trust your local network.
+# Mac and Windows users, you're on your own...
+# 2. Run this with `docker-compose -f docker-compose.yml -f docker-compose.cypress.yml up`
+version: "3.7"
+services:
+  cypress:
+    # the Docker image to use from https://github.com/cypress-io/cypress-docker-images
+    image: "cypress/included:3.8.3"
+    depends_on:
+      - node
+    environment:
+      # Display to connect to.
+      - DISPLAY
+      # Where the tested site is.
+      - CYPRESS_baseUrl=http://node:57021
+    working_dir: /e2e
+    volumes:
+      # Mount in everything.
+      - ./:/e2e
+      # X11 socket, used to connect to your X11 display.
+      - /tmp/.X11-unix:/tmp/.X11-unix
+    entrypoint: yarn run test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3.7"
 services:
   node:
     image: node:12.13.0-alpine
@@ -8,7 +8,7 @@ services:
       - root:/home/node/app
     expose:
       - 57021
-    command: 'yarn dev'
+    command: "yarn dev"
     environment:
       VIRTUAL_HOST: ddb-react.docker
       VIRTUAL_PORT: 57021

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "registry": "https://npm.pkg.github.com/"
   },
   "engines": {
-    "node": ">=12.13.0",
+    "node": ">=12.6.0",
     "yarn": ">=1.17.3"
   },
   "scripts": {
@@ -30,7 +30,7 @@
     "start:storybook:test": "NODE_ENV=test start-storybook --port 57021",
     "start:storybook:dev": "NODE_ENV=development start-storybook --port 57021",
     "dev": "concurrently --raw \"yarn start:storybook:dev\" \"yarn watch:lint:scss\"",
-    "test": "cypress run",
+    "test": "cypress run --browser chrome --headless",
     "cypress:open": "cypress open"
   },
   "devDependencies": {


### PR DESCRIPTION
We need to upgrade cypress to have it run on our version of node. Now I just changed our node requirement.

Therefore this is a non-fix.

Just to show it running with cypress run in chrome.